### PR TITLE
switches builder to use 1.25.8 golang-runtime in compass-manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.5-alpine3.18 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/compass-manager
 
-go 1.19
+go 1.20
 
 require (
 	github.com/kyma-project/lifecycle-manager v0.0.0-20230503071506-f52bd5eec10b


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- uses the latest golang-runtime for security reasons
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
