### PR TITLE
Replace default kubebuilder identifiers in helm charts with specific for compass-manager

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,7 +25,7 @@ bases:
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
-# If you want your controller-manager to expose the /metrics
+# If you want your compass-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 
 

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: compass-manager
   namespace: kcp-system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,27 +1,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: compass-manager
   namespace: kcp-system
   labels:
-    control-plane: controller-manager
+    control-plane: compass-manager
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: manager
+    app.kubernetes.io/instance: compass-manager
+    app.kubernetes.io/component: compass-manager.kyma-project.io
     app.kubernetes.io/created-by: compass-manager
     app.kubernetes.io/part-of: compass-manager
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: compass-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        app.kubernetes.io/component: compass-manager.kyma-project.io
       labels:
-        control-plane: controller-manager
+        control-plane: compass-manager
     spec:
       securityContext:
         runAsNonRoot: true
@@ -70,5 +71,5 @@ spec:
           secret:
             secretName: kcp-provisioner-credentials-file
             optional: false
-      serviceAccountName: controller-manager
+      serviceAccountName: compass-manager
       terminationGracePeriodSeconds: 10

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,14 +4,14 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: compass-manager
     app.kubernetes.io/name: servicemonitor
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/instance: compass-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: compass-manager
     app.kubernetes.io/part-of: compass-manager
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-monitor
+  name: compass-manager-metrics-monitor
   namespace: kcp-system
 spec:
   endpoints:
@@ -23,4 +23,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: compass-manager

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -4,12 +4,12 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/name: role
-    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/instance: compass-manager-le-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: compass-manager
     app.kubernetes.io/part-of: compass-manager
     app.kubernetes.io/managed-by: kustomize
-  name: leader-election-role
+  name: compass-manager-le-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -3,17 +3,17 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/instance: compass-manager-le-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: compass-manager
     app.kubernetes.io/part-of: compass-manager
     app.kubernetes.io/managed-by: kustomize
-  name: leader-election-rolebinding
+  name: compass-manager-le-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: compass-manager-le-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: compass-manager
   namespace: kcp-system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: compass-manager-role
 rules:
 - apiGroups:
   - apiextensions.k8s.io

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -3,17 +3,17 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/instance: compass-manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: compass-manager
     app.kubernetes.io/part-of: compass-manager
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: compass-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: compass-manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: compass-manager
   namespace: kcp-system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,10 +3,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/instance: compass-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: compass-manager
     app.kubernetes.io/part-of: compass-manager
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager
+  name: compass-manager
   namespace: kcp-system


### PR DESCRIPTION
Helm chat update to prevent bugs related with duplication of used pod, and rbac identifiers with other objects on the cluster.

Mainly change `controller-manager` label  to `compass-manager`

Also role and cluster-role changes to be compass-manager specific.



