### PR TITLE
Enable runtime registration in compass-manager configuration

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,7 @@ spec:
           - name: APP_DIRECTOR_OAUTH_PATH
             value: /director-secret/director.yaml
           - name : APP_ENABLED_REGISTRATION
-            value: "false"
+            value: "true"
           - name: APP_DIRECTOR_URL
             value: https://compass-gateway-auth-oauth.mps.dev.kyma.cloud.sap/director/graphql
         ports:


### PR DESCRIPTION
Setting feature flag in compass-manager` deployment APP_ENABLED_REGISTRATION to true.

It will enable the function of registration of Kyma runtimes in Compass.