### PR TITLE
Change the Compass runtime label

### DIFF
--- a/controllers/compassmanager_controller.go
+++ b/controllers/compassmanager_controller.go
@@ -413,7 +413,7 @@ func createCompassRuntimeLabels(kymaLabels map[string]string) map[string]interfa
 	runtimeLabels["broker_instance_id"] = kymaLabels[LabelBrokerInstanceID]
 	runtimeLabels["gardenerClusterName"] = kymaLabels[LabelShootName]
 	runtimeLabels["subaccount_id"] = kymaLabels[LabelSubaccountID]
-	runtimeLabels["global_account_id"] = kymaLabels[LabelGlobalAccountID]
+	runtimeLabels["global_subaccount_id"] = kymaLabels[LabelGlobalAccountID]
 	runtimeLabels["broker_plan_id"] = kymaLabels[LabelBrokerPlanID]
 	runtimeLabels["broker_plan_name"] = kymaLabels[LabelBrokerPlanName]
 

--- a/controllers/compassmanager_controller.go
+++ b/controllers/compassmanager_controller.go
@@ -412,8 +412,8 @@ func createCompassRuntimeLabels(kymaLabels map[string]string) map[string]interfa
 	runtimeLabels["director_connection_managed_by"] = ManagedBy
 	runtimeLabels["broker_instance_id"] = kymaLabels[LabelBrokerInstanceID]
 	runtimeLabels["gardenerClusterName"] = kymaLabels[LabelShootName]
-	runtimeLabels["subaccount_id"] = kymaLabels[LabelSubaccountID]
-	runtimeLabels["global_subaccount_id"] = kymaLabels[LabelGlobalAccountID]
+	runtimeLabels["global_subaccount_id"] = kymaLabels[LabelSubaccountID]
+	runtimeLabels["global_account_id"] = kymaLabels[LabelGlobalAccountID]
 	runtimeLabels["broker_plan_id"] = kymaLabels[LabelBrokerPlanID]
 	runtimeLabels["broker_plan_name"] = kymaLabels[LabelBrokerPlanName]
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- change the invalid Compass label from `global_account_id` to `global_subaccount_id`


