### PR TITLE
Disable trivy

### DIFF
--- a/.github/workflows/compass-manager.yaml
+++ b/.github/workflows/compass-manager.yaml
@@ -31,7 +31,6 @@ permissions:
 
 env:
   unit-test-log: unit-test.log
-  trivy-table: trivy-table.txt
 
 jobs:
   setup:
@@ -92,49 +91,6 @@ jobs:
           name: ${{ env.unit-test-log }}
           path: ${{ env.unit-test-log }}
 
-  trivy:
-    permissions:
-      contents: read
-    runs-on: "ubuntu-20.04"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Install trivy
-        run: |
-          mkdir ./trivy
-          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.49.1/trivy_0.49.1_Linux-64bit.tar.gz | tar xvz --directory=./trivy
-          ./trivy/trivy --version
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          scan-type: "fs"
-          scan-ref: "."
-
-          exit-code: 1
-          severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
-          ignore-unfixed: false
-          timeout: "5m0s"
-          vuln-type: "os,library"
-
-          format: table
-          output: ${{ env.trivy-table }}
-
-      - name: Upload trivy table
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.trivy-table }}
-          path: ${{ env.trivy-table }}
-
-      - name: Print trivy table
-        if: success() || failure()
-        run: cat ${{ env.trivy-table }}
-
   build-image:
     needs: setup
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -146,7 +102,7 @@ jobs:
 
   summary:
     runs-on: ubuntu-latest
-    needs: [build-image, unit-tests, trivy]
+    needs: [build-image, unit-tests]
     if: success() || failure()
     steps:
       - name: "Download test log"
@@ -154,22 +110,10 @@ jobs:
         continue-on-error: true
         with:
           name: ${{ env.unit-test-log }}
-      - name: "Download trivy log"
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: ${{ env.trivy-table }}
       - name: "Generate summary"
         run: |
           {
             echo '# Compass Manager'
-            # if trivy results table exists
-            if [ -f ${{ env.trivy-table }} ]; then
-              echo '## Trivy'
-              printf '\n```txt\n'
-              cat ${{ env.trivy-table }}
-              printf '\n```\n'
-            fi
             # if test log exists
             if [ -f ${{ env.unit-test-log }} ]; then
               echo '## Unit Tests'


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- removes trivy as it is failing in most of the times because of an external db connection issue

Example failure
```
2024-11-07T17:03:17Z	ERROR	[vulndb] Failed to download artifact	repo="ghcr.io/aquasecurity/trivy-db:2" err="oci download error: failed to fetch the layer: GET https://ghcr.io/v2/aquasecurity/trivy-db/blobs/sha256:cd1b2cc98f35a3421f3f3040c0a3247edb8f6f91f0b4a211c62fe4abc138811b: TOOMANYREQUESTS: retry-after: 724.762µs, allowed: 44000/minute"
2024-11-07T17:03:17Z	FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from any source
```


**Related issue(s)**
- https://github.com/kyma-project/infrastructure-manager/pull/481
- https://github.com/kyma-project/application-connector-manager/pull/375