### PR TITLE
Change approach of format printing after go 1.24 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= compass-manager:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.28.0
+ENVTEST_K8S_VERSION = 1.31.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -145,7 +145,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.6
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.17.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/config/crd/bases/operator.kyma-project.io_compassmanagermappings.yaml
+++ b/config/crd/bases/operator.kyma-project.io_compassmanagermappings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: compassmanagermappings.operator.kyma-project.io
 spec:
   group: operator.kyma-project.io

--- a/internal/apperrors/apperrors.go
+++ b/internal/apperrors/apperrors.go
@@ -65,32 +65,36 @@ func errorf(code ErrCode, cause CauseCode, format string, a ...interface{}) AppE
 	return appError{code: code, internalCode: cause, message: fmt.Sprintf(format, a...)}
 }
 
-func BadGateway(format string, a ...interface{}) AppError {
-	return errorf(CodeBadGateway, Unknown, format, a...)
+func BadGateway(message string) AppError {
+	return appError{code: CodeBadGateway, internalCode: Unknown, message: message}
 }
 
-func Internal(format string, a ...interface{}) AppError {
-	return errorf(CodeInternal, Unknown, format, a...)
+func Internalf(formatted string, a ...interface{}) AppError {
+	return errorf(CodeInternal, Unknown, formatted, a...)
 }
 
-func External(format string, a ...interface{}) AppError {
-	return errorf(CodeExternal, Unknown, format, a...)
+func Internal(message string) AppError {
+	return appError{code: CodeInternal, internalCode: Unknown, message: message}
 }
 
-func Forbidden(format string, a ...interface{}) AppError {
-	return errorf(CodeForbidden, Unknown, format, a...)
+func External(formatted string, a ...interface{}) AppError {
+	return errorf(CodeExternal, Unknown, formatted, a...)
 }
 
-func BadRequest(format string, a ...interface{}) AppError {
-	return errorf(CodeBadRequest, Unknown, format, a...)
+func Forbidden(formatted string, a ...interface{}) AppError {
+	return errorf(CodeForbidden, Unknown, formatted, a...)
 }
 
-func InvalidGlobalAccount(format string, a ...interface{}) AppError {
-	return errorf(CodeBadRequest, GlobalAccountNotFound, format, a...)
+func BadRequest(message string) AppError {
+	return appError{code: CodeBadRequest, internalCode: Unknown, message: message}
 }
 
-func NotFound(format string, a ...interface{}) AppError {
-	return errorf(CodeNotFound, RuntimeNotFound, format, a...)
+func NotFound(message string) AppError {
+	return appError{code: CodeNotFound, internalCode: RuntimeNotFound, message: message}
+}
+
+func InvalidGlobalAccount(message string) AppError {
+	return appError{code: CodeBadRequest, internalCode: GlobalAccountNotFound, message: message}
 }
 
 func (ae appError) Append(additionalFormat string, a ...interface{}) AppError {

--- a/internal/apperrors/apperrors_test.go
+++ b/internal/apperrors/apperrors_test.go
@@ -20,42 +20,35 @@ func TestAppError(t *testing.T) {
 	})
 
 	t.Run("should create error with formatted message", func(t *testing.T) {
-		assert.Equal(t, "code: 1, error: bug", Internal("code: %d, error: %s", 1, "bug").Error())
+		assert.Equal(t, "code: 1, error: bug", Internalf("code: %d, error: %s", 1, "bug").Error())
 		assert.Equal(t, "code: 1, error: bug", Forbidden("code: %d, error: %s", 1, "bug").Error())
-		assert.Equal(t, "code: 1, error: bug", BadRequest("code: %d, error: %s", 1, "bug").Error())
 	})
 
 	t.Run("should append apperrors without changing error code", func(t *testing.T) {
 		// given
-		createdInternalErr := Internal("Some Internal apperror, %s", "Some pkg err")
+		createdInternalErr := Internalf("Some Internal apperror, %s", "Some pkg err")
 		createdForbiddenErr := Forbidden("Some Forbidden apperror, %s", "Some pkg err")
-		createdBadRequestErr := BadRequest("Some BadRequest apperror, %s", "Some pkg err")
 
 		// when
 		appendedInternalErr := createdInternalErr.Append("Some additional message")
 		appendedForbiddenErr := createdForbiddenErr.Append("Some additional message")
-		appendedBadRequestErr := createdBadRequestErr.Append("Some additional message")
 
 		// then
 		assert.Equal(t, CodeInternal, appendedInternalErr.Code())
 		assert.Equal(t, CodeForbidden, appendedForbiddenErr.Code())
-		assert.Equal(t, CodeBadRequest, appendedBadRequestErr.Code())
 	})
 
 	t.Run("should append apperrors and chain messages correctly", func(t *testing.T) {
 		// given
-		createdInternalErr := Internal("Some Internal apperror, %s", "Some pkg err")
+		createdInternalErr := Internalf("Some Internal apperror, %s", "Some pkg err")
 		createdForbiddenErr := Forbidden("Some Forbidden apperror, %s", "Some pkg err")
-		createdBadRequestErr := BadRequest("Some BadRequest apperror, %s", "Some pkg err")
 
 		// when
 		appendedInternalErr := createdInternalErr.Append("Some additional message: %s", "error")
 		appendedForbiddenErr := createdForbiddenErr.Append("Some additional message: %s", "error")
-		appendedBadRequestErr := createdBadRequestErr.Append("Some additional message: %s", "error")
 
 		// then
 		assert.Equal(t, "Some additional message: error, Some Internal apperror, Some pkg err", appendedInternalErr.Error())
 		assert.Equal(t, "Some additional message: error, Some Forbidden apperror, Some pkg err", appendedForbiddenErr.Error())
-		assert.Equal(t, "Some additional message: error, Some BadRequest apperror, Some pkg err", appendedBadRequestErr.Error())
 	})
 }

--- a/internal/apperrors/presenter.go
+++ b/internal/apperrors/presenter.go
@@ -32,9 +32,9 @@ func (p *presenter) Do(ctx context.Context, err error) *gqlerror.Error {
 	return newGraphqlErrorResponse(ctx, customErr.Code(), customErr.Reason(), customErr.Component(), customErr.Error())
 }
 
-func newGraphqlErrorResponse(ctx context.Context, code ErrCode, reason ErrReason, component ErrComponent, msg string, args ...interface{}) *gqlerror.Error {
+func newGraphqlErrorResponse(ctx context.Context, code ErrCode, reason ErrReason, component ErrComponent, args ...interface{}) *gqlerror.Error {
 	return &gqlerror.Error{
-		Message: fmt.Sprintf(msg, args...),
+		Message: fmt.Sprintf("%s", args...),
 		Path:    graphql.GetFieldContext(ctx).Path(),
 		Extensions: map[string]interface{}{
 			"error_component": component,

--- a/internal/director/directorclient.go
+++ b/internal/director/directorclient.go
@@ -69,7 +69,7 @@ func (cc *directorClient) CreateRuntime(config *gqlschema.RuntimeInput, globalAc
 	runtimeInput, err := cc.graphqlizer.RuntimeRegisterInputToGQL(directorInput)
 	if err != nil {
 		log.Infof("Failed to create graphQLized Runtime input")
-		return "", apperrors.Internal("Failed to create graphQLized Runtime input: %s", err.Error()).SetComponent(apperrors.ErrCompassDirectorClient).SetReason(apperrors.ErrDirectorClientGraphqlizer)
+		return "", apperrors.Internalf("Failed to create graphQLized Runtime input: %s", err.Error()).SetComponent(apperrors.ErrCompassDirectorClient).SetReason(apperrors.ErrDirectorClientGraphqlizer)
 	}
 
 	runtimeQuery := cc.queryProvider.createRuntimeMutation(runtimeInput)
@@ -106,10 +106,10 @@ func (cc *directorClient) GetRuntime(compassID, globalAccount string) (graphql.R
 		return graphql.RuntimeExt{}, err.Append("Failed to get runtime %s from Director", compassID)
 	}
 	if response.Result == nil {
-		return graphql.RuntimeExt{}, apperrors.Internal("Failed to get runtime %s from Director: received nil response.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorNilResponse)
+		return graphql.RuntimeExt{}, apperrors.Internalf("Failed to get runtime %s from Director: received nil response.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorNilResponse)
 	}
 	if response.Result.ID != compassID {
-		return graphql.RuntimeExt{}, apperrors.Internal("Failed to get runtime %s from Director: received unexpected RuntimeID", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorRuntimeIDMismatch)
+		return graphql.RuntimeExt{}, apperrors.Internalf("Failed to get runtime %s from Director: received unexpected RuntimeID", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorRuntimeIDMismatch)
 	}
 
 	log.Infof("Successfully got Runtime %s from Director for Global Account %s", compassID, globalAccount)
@@ -126,7 +126,7 @@ func (cc *directorClient) GetConnectionToken(compassID, globalAccount string) (g
 	}
 
 	if response.Result == nil {
-		return graphql.OneTimeTokenForRuntimeExt{}, apperrors.Internal("Failed to get OneTimeToken for Runtime %s in Director: received nil response.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorNilResponse)
+		return graphql.OneTimeTokenForRuntimeExt{}, apperrors.Internalf("Failed to get OneTimeToken for Runtime %s in Director: received nil response.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorNilResponse)
 	}
 
 	log.Infof("Received OneTimeToken for Runtime %s in Director for Global Account %s", compassID, globalAccount)
@@ -148,11 +148,11 @@ func (cc *directorClient) DeleteRuntime(compassID, globalAccount string) apperro
 	}
 	// Nil check is necessary due to GraphQL client not checking response code
 	if response.Result == nil {
-		return apperrors.Internal("Failed to unregister runtime %s in Director: received nil response.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorNilResponse)
+		return apperrors.Internalf("Failed to unregister runtime %s in Director: received nil response.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorNilResponse)
 	}
 
 	if response.Result.ID != compassID {
-		return apperrors.Internal("Failed to unregister runtime %s in Director: received unexpected RuntimeID.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorRuntimeIDMismatch)
+		return apperrors.Internalf("Failed to unregister runtime %s in Director: received unexpected RuntimeID.", compassID).SetComponent(apperrors.ErrCompassDirector).SetReason(apperrors.ErrDirectorRuntimeIDMismatch)
 	}
 
 	log.Infof("Successfully unregistered Runtime %s in Director for tenant %s", compassID, globalAccount)
@@ -191,7 +191,7 @@ func (cc *directorClient) executeDirectorGraphQLCall(directorQuery string, globa
 		if errors.As(err, &egErr) {
 			return mapDirectorErrorToProvisionerError(egErr, gracefulUnregistration).Append("Failed to execute GraphQL request to Director")
 		}
-		return apperrors.Internal("Failed to execute GraphQL request to Director: %v", err)
+		return apperrors.Internalf("Failed to execute GraphQL request to Director: %v", err)
 	}
 
 	return nil
@@ -200,11 +200,11 @@ func (cc *directorClient) executeDirectorGraphQLCall(directorQuery string, globa
 func mapDirectorErrorToProvisionerError(egErr gcli.ExtendedError, gracefulUnregistration bool) apperrors.AppError {
 	errorCodeValue, present := egErr.Extensions()["error_code"]
 	if !present {
-		return apperrors.Internal("Failed to read the error code from the error response. Original error: %v", egErr)
+		return apperrors.Internalf("Failed to read the error code from the error response. Original error: %v", egErr)
 	}
 	errorCode, ok := errorCodeValue.(float64)
 	if !ok {
-		return apperrors.Internal("Failed to cast the error code from the error response. Original error: %v", egErr)
+		return apperrors.Internalf("Failed to cast the error code from the error response. Original error: %s", egErr)
 	}
 
 	var err apperrors.AppError
@@ -227,7 +227,7 @@ func mapDirectorErrorToProvisionerError(egErr gcli.ExtendedError, gracefulUnregi
 	case directorApperrors.TenantRequired, directorApperrors.TenantNotFound:
 		err = apperrors.InvalidGlobalAccount(egErr.Error())
 	default:
-		err = apperrors.Internal("Did not recognize the error code from the error response. Original error: %v", egErr)
+		err = apperrors.Internalf("Did not recognize the error code from the error response. Original error: %v", egErr)
 	}
 
 	return err.SetComponent(apperrors.ErrCompassDirector).SetReason(reason)

--- a/internal/oauth/client.go
+++ b/internal/oauth/client.go
@@ -49,7 +49,7 @@ func (c *oauthClient) getAuthorizationToken(credentials credentials) (Token, app
 	request, err := http.NewRequest(http.MethodPost, credentials.tokensEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		log.Errorf("Failed to create authorisation token request")
-		return Token{}, apperrors.Internal("Failed to create authorisation token request: %s", err.Error())
+		return Token{}, apperrors.Internalf("Failed to create authorisation token request: %s", err.Error())
 	}
 
 	now := time.Now().Unix()
@@ -59,7 +59,7 @@ func (c *oauthClient) getAuthorizationToken(credentials credentials) (Token, app
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return Token{}, apperrors.Internal("Failed to execute http call: %s", err.Error())
+		return Token{}, apperrors.Internalf("Failed to execute http call: %s", err.Error())
 	}
 	defer util.Close(response.Body)
 
@@ -73,14 +73,14 @@ func (c *oauthClient) getAuthorizationToken(credentials credentials) (Token, app
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return Token{}, apperrors.Internal("Failed to read token response body from '%s': %s", credentials.tokensEndpoint, err.Error())
+		return Token{}, apperrors.Internalf("Failed to read token response body from '%s': %s", credentials.tokensEndpoint, err.Error())
 	}
 
 	tokenResponse := Token{}
 
 	err = json.Unmarshal(body, &tokenResponse)
 	if err != nil {
-		return Token{}, apperrors.Internal("failed to unmarshal token response body: %s", err.Error())
+		return Token{}, apperrors.Internalf("failed to unmarshal token response body: %s", err.Error())
 	}
 
 	log.Infof("Successfully unmarshal response oauth token for accessing Director")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
In Go 1.24 the `go vet` and printf analyzer are now more strictly checking the format string. More information can be found at [Go 1.24 Release Page](https://tip.golang.org/doc/go1.24#vet).

Changes proposed in this pull request:

- aligned with the new approach of printing in Go 1.24,
- updated the controller-gen and k8s version used by the controller test.

