### PR TITLE
go.mod golang bump 1.24.2 -> 1.24.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/compass-manager
 
-go 1.24.2
+go 1.24.5
 
 require (
 	github.com/99designs/gqlgen v0.17.43


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- go.mod golang bump 1.24.2 -> 1.24.5 . Unfortunately it does not fixes yet the `CVE-2025-47906` as [the fix was only done on main branch and not yet released](https://github.com/golang/go/commit/e0b07dc22eaab1b003d98ad6d63cdfacc76c5c70) (I checked that on Blackduck by manually uploading the image)
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
