### PR TITLE
aligning if statement for build job summary

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -97,7 +97,7 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: build-image
-    if: always() && contains(needs.*.result, 'success')
+    if: needs.build-image.result == 'success'
     steps:
       - name: "Generate summary"
         run: |


### PR DESCRIPTION
Aligns when build workflow summary step is executed with how it is done in other repository, e.g. here: https://github.com/kyma-project/subscription-cleanup-job/commit/c06182b192e3b5e40ff4ace053693f27e7b36ab6 
