### PR TITLE
Fix govulncheck-action

### DIFF
--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -9,9 +9,6 @@ jobs:
   govuln:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
     - name: vulncheck
       uses: golang/govulncheck-action@v1
       with:


### PR DESCRIPTION
# Fix `govulncheck-action` Workflow

### Bug Fix

🐛 Fixed the `run-vuln-check.yaml` GitHub Actions workflow by removing a redundant and incorrectly versioned `actions/checkout` step that was causing the workflow to fail.

### Changes

* `.github/workflows/run-vuln-check.yaml`: Removed the explicit `actions/checkout@v6` step (which used a non-existent version) since `golang/govulncheck-action` handles repository checkout internally.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `80c17aca-d912-48ce-a25b-cf5697b79caf`
</details>
