### PR TITLE
Add component-config.yaml

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,0 +1,4 @@
+name: kyma-project.io/kyma-runtime/kcp-components/compass-manager
+team: kyma/framefrog
+images:
+  - europe-docker.pkg.dev/kyma-project/prod/compass-manager:latest


### PR DESCRIPTION
## Summary

This PR adds a `component-config.yaml` file at the repository root, following the same pattern established by the `infrastructure-manager` repository.

The file defines:
- The component name under the `kyma-project.io/kyma-runtime/kcp-components/` namespace
- The owning team (`kyma/framefrog`)
- The list of container images produced by this module (`europe-docker.pkg.dev/kyma-project/prod/compass-manager:latest`)

This config is used to register the component and its images in the KCP component registry.