### PR TITLE
fix: remove protected environment gate from upload-release-report workflow

### DIFF
--- a/.github/workflows/upload-release-report.yaml
+++ b/.github/workflows/upload-release-report.yaml
@@ -21,20 +21,11 @@ on:
 jobs:
   upload-release-report:
     runs-on: ubuntu-latest
-    environment: ${{ vars.PROTECTED_ENVIRONMENT }}
-
     permissions:
       actions: read
       contents: read
 
     steps:
-      - name: Check required environment variable
-        run: |
-          if [ -z "${{ vars.PROTECTED_ENVIRONMENT }}" ]; then
-            echo "Error: PROTECTED_ENVIRONMENT variable is not set"
-            exit 1
-          fi
-
       - name: Set release version
         run: |
           echo "RELEASE_VERSION=${{ inputs.release_version }}" >> $GITHUB_ENV
@@ -84,3 +75,5 @@ jobs:
           REPO: ${{ github.event.repository.name }}
         run: |
           gsutil cp "${REPO}_${RELEASE_VERSION}.zip" gs://kyma_release_test_logs/
+
+


### PR DESCRIPTION
## Problem

The `upload-release-report` workflow had `environment: ${{ vars.PROTECTED_ENVIRONMENT }}` set on the job. The `protected` environment has a required reviewers rule (team Framefrog), which causes GitHub to block automated tag-triggered deployments with:

> Tag "1.0.31" is not allowed to deploy to protected due to environment protection rules.

This caused the 1.0.31 release workflow to fail in 6 seconds.

## Fix

- Remove `environment: ${{ vars.PROTECTED_ENVIRONMENT }}` from the job definition
- Remove the "Check required environment variable" step that only existed to validate that env var

This aligns the workflow with the working `infrastructure-manager` repo, which does not use an environment gate in its `upload-release-report` workflow.