### PR TITLE
Skip file detection for workflow_call events in build-image.yaml

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -66,7 +66,7 @@ jobs:
         run: echo "latest=latest" >> $GITHUB_OUTPUT
       - name: Detect files
         id: detect-files
-        if: github.event_name != 'workflow_call'  # Skip detection for workflow_call (releases)
+        if: github.event_name != 'workflow_call'  # Skip detection for workflow_call (releases); fallback-values will set code_any_changed=true
         continue-on-error: true
         uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad
         with:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -66,6 +66,7 @@ jobs:
         run: echo "latest=latest" >> $GITHUB_OUTPUT
       - name: Detect files
         id: detect-files
+        if: github.event_name != 'workflow_call'  # Skip detection for workflow_call (releases)
         continue-on-error: true
         uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad
         with:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -59,6 +59,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
       - id: tag
         run: echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
       - id: latest


### PR DESCRIPTION
## Problem

1. Release tag pushes skip the build-image job, resulting in no Docker image being built
2. Fork PRs fail during checkout with error about `pull_request_target` security

Example release issue: https://github.com/kyma-project/compass-manager/actions/runs/29815885726

## Root Cause

1. **Release builds**: File change detection fails during `workflow_call` events (release tags) because there's no "before" commit to compare against, causing `code_any_changed` to be false and skipping the image build
2. **Fork PRs**: actions/checkout@v6 refuses to checkout fork code in `pull_request_target` workflows without explicit opt-in

## Solution

1. Skip file detection for `workflow_call` events by adding `if: github.event_name != 'workflow_call'`. When skipped, the existing fallback automatically sets `code_any_changed=true`, ensuring images are always built for releases
2. Add `allow-unsafe-pr-checkout: true` to the checkout step. This is safe because fork PRs are protected by the `gate` job requiring environment approval
